### PR TITLE
has Many with polymorphic relationship query with limit bug

### DIFF
--- a/common/models/image.js
+++ b/common/models/image.js
@@ -1,0 +1,3 @@
+module.exports = function(Image) {
+
+};

--- a/common/models/image.json
+++ b/common/models/image.json
@@ -1,0 +1,22 @@
+{
+  "name": "image",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "path": {
+      "type": "string"
+    }
+  },
+  "validations": [],
+  "relations": {
+    "imageable": {
+      "type": "belongsTo",
+      "polymorphic": true
+    }
+  },
+  "acls": [],
+  "methods": {}
+}

--- a/common/models/item.js
+++ b/common/models/item.js
@@ -1,0 +1,3 @@
+module.exports = function(Item) {
+
+};

--- a/common/models/item.json
+++ b/common/models/item.json
@@ -1,0 +1,23 @@
+{
+  "name": "item",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "validations": [],
+  "relations": {
+    "images": {
+      "type": "hasMany",
+      "model": "image",
+      "polymorphic": "imageable"
+    }
+  },
+  "acls": [],
+  "methods": {}
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "pretest": "jshint ."
   },
   "dependencies": {
+    "bluebird": "^2.9.34",
     "compression": "^1.0.3",
     "cors": "^2.5.2",
     "errorhandler": "^1.1.1",

--- a/server/boot/fakeData.js
+++ b/server/boot/fakeData.js
@@ -1,0 +1,19 @@
+module.exports = function(app, cb){
+  var Item = app.models.item;
+  var Image= app.models.image;
+  var Promise = require('bluebird');
+
+  Item.create([
+   {name: 'item 1'},
+   {name: 'item 2'},
+  ]).then(function(items){
+    return Promise.map(items, function(item){
+      return item.images.create([
+        {path: '1'},
+        {path: '2'}
+      ])
+    });
+  }).then(function(){
+    cb();
+  });
+};

--- a/server/middleware.json
+++ b/server/middleware.json
@@ -12,16 +12,11 @@
       }
     }
   },
-  "session": {
-  },
-  "auth": {
-  },
-  "parse": {
-  },
-  "routes": {
-  },
-  "files": {
-  },
+  "session": {},
+  "auth": {},
+  "parse": {},
+  "routes": {},
+  "files": {},
   "final": {
     "loopback#urlNotFound": {}
   },

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -31,5 +31,13 @@
   "Role": {
     "dataSource": "db",
     "public": false
+  },
+  "item": {
+    "dataSource": "db",
+    "public": true
+  },
+  "image": {
+    "dataSource": "db",
+    "public": true
   }
 }

--- a/test/relation.js
+++ b/test/relation.js
@@ -7,15 +7,17 @@ var assert = require('assert');
 describe('HasMany with Polymorphic query with scope', function() {
 
   beforeEach(function(done) {
-    Item.create([
-      { name: 'item 1' },
-      { name: 'item 2' },
-      { name: 'item 3' }
-    ], function(err, items) {
-      Promise.map(items, function(item){
-        return item.images.create([{path: 1}, {path: 2}])
-      }).then(function(images){
-        done()
+    app.datasources.db.automigrate(function(){
+      Item.create([
+        { name: 'item 1' },
+        { name: 'item 2' },
+        { name: 'item 3' }
+      ], function(err, items) {
+        Promise.map(items, function(item){
+          return item.images.create([{path: 1}, {path: 2}])
+        }).then(function(images){
+          done()
+        });
       });
     });
   })

--- a/test/relation.js
+++ b/test/relation.js
@@ -1,0 +1,42 @@
+var app   = require('../server/server.js');
+var Item  = app.models.item;
+var Image = app.models.image;
+var Promise = require('bluebird');
+var assert = require('assert');
+
+describe('HasMany with Polymorphic query with scope', function() {
+
+  beforeEach(function(done) {
+    Item.create([
+      { name: 'item 1' },
+      { name: 'item 2' },
+      { name: 'item 3' }
+    ], function(err, items) {
+      Promise.map(items, function(item){
+        return item.images.create([{path: 1}, {path: 2}])
+      }).then(function(images){
+        done()
+      });
+    });
+  })
+
+  it('should return 1 image each items', function(done){
+    Item.find({
+      include: {
+        relation: 'images',
+        scope: {
+          limit: 1
+        }
+      }
+    }, function(err, items){
+      items = items.map(function(item){
+        return item.toJSON();
+      });
+      console.log(items);
+      assert.equal(items[0].images.length, 1);
+      assert.equal(items[1].images.length, 1);
+      assert.equal(items[2].images.length, 1);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
when query an item with its associated images with 

```
Item.find({
  include: { relation: 'images', scope: { limit: 1}}
})
```

only the first item will have its associate images. 

I've created a test for this, simply run `mocha test`.

Also, only when you increase the limit number, the following items will get its associate images. i.e. when increase limit to 3, the first item will get its 2 associate images, and the second item will only get one image, the third item still has non images. 

I also added some sample data in boot/fakeData.js, you can view the behaviour in explorer.
