### PR TITLE
Upgrade dependencies, drop Node.js 0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "loopback-sandbox",
   "version": "1.0.0",
   "main": "server/server.js",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "scripts": {
     "lint": "eslint .",
     "start": "node .",
@@ -10,18 +13,18 @@
   "dependencies": {
     "compression": "^1.0.3",
     "cors": "^2.5.2",
-    "helmet": "^1.3.0",
-    "loopback-boot": "^2.6.5",
-    "loopback-component-explorer": "^2.4.0",
+    "helmet": "^3.11.0",
+    "loopback": "^3.18.2",
+    "loopback-boot": "^3.1.0",
+    "loopback-component-explorer": "^5.3.0",
     "serve-favicon": "^2.0.1",
-    "strong-error-handler": "^1.0.1",
-    "loopback-datasource-juggler": "^2.39.0",
-    "loopback": "^2.22.0"
+    "strong-error-handler": "^2.3.1"
   },
   "devDependencies": {
-    "eslint": "^2.13.1",
-    "eslint-config-loopback": "^4.0.0",
-    "nsp": "^2.1.0"
+    "eslint": "^4.18.1",
+    "eslint-config-loopback": "^10.0.0",
+    "eslint-plugin-mocha": "^4.11.0",
+    "nsp": "^2.8.1"
   },
   "repository": {
     "type": "",


### PR DESCRIPTION
 - Drop support for Node.js version older than 4.x
 - Upgrade LoopBack from 2.x to 3.x
 - Upgrade other dependencies to their latest versions

This commit fixes the following security vulnerability in lodash:

 - Prototype Pollution https://snyk.io/vuln/npm:lodash:20180130