### PR TITLE
Remove nsp check to fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint .",
     "start": "node .",
-    "posttest": "npm run lint && nsp check"
+    "posttest": "npm run lint"
   },
   "dependencies": {
     "compression": "^1.0.3",
@@ -23,8 +23,7 @@
   "devDependencies": {
     "eslint": "^4.18.1",
     "eslint-config-loopback": "^10.0.0",
-    "eslint-plugin-mocha": "^5.0.0",
-    "nsp": "^3.2.1"
+    "eslint-plugin-mocha": "^5.0.0"
   },
   "repository": {
     "type": "",


### PR DESCRIPTION
nsp is no longer supported and fails with the following error:

    getaddrinfo ENOTFOUND api.nodesecurity.io api.nodesecurity.io:443

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
